### PR TITLE
Add PlayStation inspired boot screen

### DIFF
--- a/public/assets/ps1-logo.svg
+++ b/public/assets/ps1-logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 80">
+  <text x="10" y="60" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="60" fill="#e50914">P</text>
+  <text x="80" y="60" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="60" fill="#f5d300">S</text>
+  <text x="140" y="60" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="60" fill="#53b5ff">1</text>
+</svg>

--- a/src/components/dialogs/BootScreen.tsx
+++ b/src/components/dialogs/BootScreen.tsx
@@ -68,28 +68,23 @@ export function BootScreen({
   return (
     <Dialog open={isOpen} onOpenChange={() => {}} modal>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay 
-          className="fixed inset-0 z-[75] bg-neutral-500/90 backdrop-blur-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+        <DialogPrimitive.Overlay
+          className="fixed inset-0 z-[75] bg-black data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
           style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 }}
         />
-        <DialogContent 
-          className=" bg-neutral-100 p-0 w-[calc(100%-24px)] border-none shadow-xl max-w-lg z-[80] outline-none"
+        <DialogContent
+          className="bg-black p-0 w-[calc(100%-24px)] border-none shadow-none max-w-md z-[80] outline-none"
           style={{ position: 'fixed', zIndex: 80 }}
         >
           <VisuallyHidden>
             <DialogTitle>{title}</DialogTitle>
           </VisuallyHidden>
-          <div className="flex flex-col items-center justify-center p-8 min-h-[300px] w-full">
-            <div className="flex flex-col items-center justify-center border border-neutral-200 bg-white p-8 w-full pb-4">
-                <img src="/assets/macos.svg" alt="macOS" className="w-64 h-32" />
-                <h1 className="text-[36px] font-mondwest mt-4 mb-0">
-                  <span className="text-blue-500">ry</span>OS 8.2
-                </h1>
-            </div>
-            <h2 className="text-[16px] font-chicago mt-4 mb-1">{title}</h2>
-            <div className="w-[50%] h-3 border-1 border-neutral-500 rounded-sm overflow-hidden">
-              <div 
-                className="h-full bg-neutral-900 transition-all duration-200"
+          <div className="flex flex-col items-center justify-center p-8 min-h-[300px] w-full text-white">
+            <img src="/assets/ps1-logo.svg" alt="PlayStation" className="w-48 h-24" />
+            <h2 className="text-[16px] font-neuebit mt-8 mb-2">{title}</h2>
+            <div className="w-[50%] h-2 border border-neutral-700 rounded-sm overflow-hidden">
+              <div
+                className="h-full bg-white transition-all duration-200"
                 style={{ width: `${progress}%` }}
               />
             </div>


### PR DESCRIPTION
## Summary
- update BootScreen with PlayStation 1 style colors
- include simple PS1 style logo asset

## Testing
- `bun run lint` *(fails: Cannot find package '@eslint/js')*
- `bun run build` *(fails: various TypeScript errors)*